### PR TITLE
target/riscv/cpu.c: fix typo ->vlen should be ->elen

### DIFF
--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -568,7 +568,7 @@ static void riscv_cpu_realize(DeviceState *dev, Error **errp)
                         "Vector extension ELEN must be power of 2");
                 return;
             }
-            if (cpu->cfg.elen > 64 || cpu->cfg.vlen < 8) {
+            if (cpu->cfg.elen > 64 || cpu->cfg.elen < 8) {
                 error_setg(errp,
                         "Vector extension implementation only supports ELEN "
                         "in the range [8, 64]");


### PR DESCRIPTION
Fix typo in this line:

https://github.com/sifive/qemu/blob/e948e0884ba75a0f0d4ac28162f8c1fddef0fcc0/target/riscv/cpu.c#L571

`vlen` should be `elen`.